### PR TITLE
Added logic for tranfers with a target

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/bep/debounce v1.2.1
 	github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086
-	github.com/egfanboy/mediapire-common v0.0.0-20240522004433-cbd1b5041bc7
+	github.com/egfanboy/mediapire-common v0.0.0-20250220152424-aaced2cf3cdc
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/google/uuid v1.4.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086 h1:ORubSQoKnncsBnR4zD9CuYFJCPOCuSNEpWEZrDdBXkc=
 github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086/go.mod h1:Z3Lomva4pyMWYezjMAU5QWRh0p1VvO4199OHlFnyKkM=
-github.com/egfanboy/mediapire-common v0.0.0-20240522004433-cbd1b5041bc7 h1:2icXJQ+GwLQwHD8ikzMfT2WvV6lgIcs4g4VX2y+QN6w=
-github.com/egfanboy/mediapire-common v0.0.0-20240522004433-cbd1b5041bc7/go.mod h1:fkbcyi+5inobqkjLF9wtVdDioekNiFixiXgHBi0UEpQ=
+github.com/egfanboy/mediapire-common v0.0.0-20250220152424-aaced2cf3cdc h1:26nL98ESgbwd/vB+2PAorBgAd0YxHHMNDHdDyvlFXp4=
+github.com/egfanboy/mediapire-common v0.0.0-20250220152424-aaced2cf3cdc/go.mod h1:fkbcyi+5inobqkjLF9wtVdDioekNiFixiXgHBi0UEpQ=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=

--- a/internal/media/async.go
+++ b/internal/media/async.go
@@ -59,13 +59,7 @@ func handleTransferMessage(ctx context.Context, msg amqp091.Delivery) error {
 
 	mediaService := NewMediaService()
 
-	// TODO: refactor common struct to use string ids
-	in := make([]string, len(input))
-	for _, v := range input {
-		in = append(in, v.String())
-	}
-
-	content, err := mediaService.DownloadMedia(ctx, in)
+	content, err := mediaService.DownloadMedia(ctx, input)
 	if err != nil {
 		msg := err.Error()
 		sendTransferUpdateMessage(ctx, tMsg.Id, &msg)
@@ -134,13 +128,7 @@ func handleDeleteMessage(ctx context.Context, msg amqp091.Delivery) error {
 
 	mediaService := NewMediaService()
 
-	// TODO: refactor common struct to use string ids
-	in := make([]string, len(input))
-	for _, v := range input {
-		in = append(in, v.String())
-	}
-
-	err = mediaService.DeleteMedia(ctx, in)
+	err = mediaService.DeleteMedia(ctx, input)
 	if err != nil {
 		log.Err(err).Msg("Failed to delete all requested media")
 	}

--- a/internal/media/factories.go
+++ b/internal/media/factories.go
@@ -93,7 +93,7 @@ func mp3Factory(path string, ext string) (item types.MediaItem, err error) {
 func hashMp3FileForId(item types.MediaItem) string {
 	metadata := item.Metadata.(Mp3Metadata)
 
-	data := fmt.Sprintf("%s-%s-%s-%d", metadata.Artist, metadata.Album, metadata.Title, metadata.TrackOf)
+	data := fmt.Sprintf("%s-%s-%s-%s-%d", item.ParentDir, metadata.Artist, metadata.Album, metadata.Title, metadata.TrackOf)
 	hash := sha256.Sum256([]byte(data))
 	hashStr := hex.EncodeToString(hash[:])
 

--- a/internal/media/media-service.go
+++ b/internal/media/media-service.go
@@ -259,14 +259,14 @@ func (s *mediaService) DownloadMedia(ctx context.Context, ids []string) ([]byte,
 
 	items := make([]types.MediaItem, len(ids))
 
-	for _, itemId := range ids {
+	for i, itemId := range ids {
 		item, err := s.getMediaItemFromId(ctx, itemId)
 		if err != nil {
 			log.Err(err).Msgf("Failed to get item with id %q", itemId)
 			return nil, err
 		}
 
-		items = append(items, item)
+		items[i] = item
 	}
 
 	groupingFuncs := getGroupingFactories(s.app.FileTypes...)
@@ -352,7 +352,7 @@ func (s *mediaService) removeItemFromCache(item types.MediaItem) error {
 	if parentDirCache, ok := mediaCache.GetKey(item.ParentDir); !ok {
 		return fmt.Errorf("parent dir for item %q is not in the cache", item.Id)
 	} else {
-		newCache := make([]types.MediaItem, mediaCache.Len())
+		newCache := make([]types.MediaItem, 0)
 
 		for _, cachedItem := range parentDirCache {
 			// different item, add it to the new cache

--- a/internal/transfers/async.go
+++ b/internal/transfers/async.go
@@ -1,0 +1,146 @@
+package transfers
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/egfanboy/mediapire-common/messaging"
+	"github.com/egfanboy/mediapire-media-host/internal/app"
+	"github.com/egfanboy/mediapire-media-host/internal/rabbitmq"
+	"github.com/rabbitmq/amqp091-go"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// filepath.Dir returns . if the path in question does not have a parent
+	noParentDir = "."
+)
+
+func handleTransferMessage(ctx context.Context, msg amqp091.Delivery) error {
+	var tMsg messaging.TransferReadyMessage
+
+	// acknowledge the message
+	msg.Ack(false)
+
+	log.Info().Msg("Received transfer ready message for transfer")
+
+	err := json.Unmarshal(msg.Body, &tMsg)
+	if err != nil {
+		msg := "failed to unmarshal transfer ready message"
+		log.Err(err).Msg(msg)
+
+		sendTransferUpdateMessage(ctx, tMsg.TransferId, &msg)
+		return err
+	}
+
+	appInstance := app.GetApp()
+
+	if tMsg.TargetId != appInstance.NodeId {
+		log.Info().Msg("Transfer ready message is not for us. Skipping.")
+
+		return nil
+	}
+
+	if tMsg.Content == nil || len(tMsg.Content) == 0 {
+		log.Info().Msgf("Content for transfer %s is empty. Skipping.", tMsg.TransferId)
+
+		return nil
+	}
+
+	reader := bytes.NewReader(tMsg.Content)
+
+	zipReader, err := zip.NewReader(reader, int64(len(tMsg.Content)))
+	if err != nil {
+		msg := fmt.Sprintf("failed to read zip file content for transfer %s", tMsg.TransferId)
+		log.Err(err).Msg(msg)
+
+		sendTransferUpdateMessage(ctx, tMsg.TransferId, &msg)
+		return err
+	}
+
+	for _, f := range zipReader.File {
+		rc, err := f.Open()
+		if err != nil {
+			msg := fmt.Sprintf("failed to open file %s  for transfer %s", f.Name, tMsg.TransferId)
+			log.Err(err).Msg(msg)
+
+			sendTransferUpdateMessage(ctx, tMsg.TransferId, &msg)
+			return err
+		}
+
+		defer rc.Close()
+
+		// for now save it in the first directory in the config
+		targetDir := appInstance.Directories[0]
+
+		fileDir := filepath.Dir(f.Name)
+		if fileDir != noParentDir {
+			err := os.MkdirAll(path.Join(targetDir, fileDir), os.ModePerm)
+			if err != nil {
+				msg := err.Error()
+				log.Err(err).Msg(msg)
+				sendTransferUpdateMessage(ctx, tMsg.TransferId, &msg)
+				return err
+			}
+		}
+
+		file, err := os.Create(path.Join(targetDir, f.Name))
+		if err != nil {
+			msg := fmt.Sprintf("failed to create file for %s for transfer %s", f.Name, tMsg.TransferId)
+			log.Err(err).Msg(msg)
+			sendTransferUpdateMessage(ctx, tMsg.TransferId, &msg)
+			return err
+		}
+
+		defer file.Close()
+
+		_, err = io.Copy(file, rc)
+		if err != nil {
+			msg := fmt.Sprintf(
+				"failed to write content for file %s to target file on mediahost for transfer %s",
+				f.Name,
+				tMsg.TransferId,
+			)
+
+			log.Err(err).Msg(msg)
+
+			sendTransferUpdateMessage(ctx, tMsg.TransferId, &msg)
+			return err
+		}
+	}
+
+	// success
+	sendTransferUpdateMessage(ctx, tMsg.TransferId, nil)
+
+	return nil
+}
+
+func sendTransferUpdateMessage(ctx context.Context, transferId string, failureReason *string) {
+	msg := messaging.TransferReadyUpdateMessage{
+		TransferId: transferId,
+	}
+
+	if failureReason != nil {
+		msg.Success = false
+		msg.FailureReason = *failureReason
+	} else {
+		msg.Success = true
+
+	}
+
+	err := rabbitmq.PublishMessage(ctx, messaging.TopicTransferReadyUpdate, msg)
+	if err != nil {
+		log.Err(err).Msg("Failed to send transfer update message")
+	}
+}
+
+func init() {
+	rabbitmq.RegisterConsumer(handleTransferMessage, messaging.TopicTransferReady)
+}

--- a/pkg/api/media-host-client.go
+++ b/pkg/api/media-host-client.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/egfanboy/mediapire-media-host/pkg/types"
-	"github.com/google/uuid"
 )
 
 const (
@@ -20,10 +19,10 @@ const (
 
 type MediaHostApi interface {
 	GetMedia(ctx context.Context, mediaTypes *[]string) ([]types.MediaItem, *http.Response, error)
-	StreamMedia(ctx context.Context, mediaId uuid.UUID) ([]byte, *http.Response, error)
+	StreamMedia(ctx context.Context, mediaId string) ([]byte, *http.Response, error)
 	DownloadTransfer(ctx context.Context, transferId string) ([]byte, *http.Response, error)
 	GetSettings(ctx context.Context) (types.MediaHostSettings, *http.Response, error)
-	GetMediaArt(ctx context.Context, mediaId uuid.UUID) ([]byte, *http.Response, error)
+	GetMediaArt(ctx context.Context, mediaId string) ([]byte, *http.Response, error)
 }
 
 func buildUriFromHost(h types.Host, apiUri string) string {
@@ -62,8 +61,8 @@ func (c *mediaHostClient) GetMedia(ctx context.Context, mediaTypes *[]string) (r
 	return
 }
 
-func (c *mediaHostClient) StreamMedia(ctx context.Context, mediaId uuid.UUID) (b []byte, r *http.Response, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, buildUriFromHost(c.host, fmt.Sprintf("%s/stream?id=%q", baseMediaPath, mediaId)), nil)
+func (c *mediaHostClient) StreamMedia(ctx context.Context, mediaId string) (b []byte, r *http.Response, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, buildUriFromHost(c.host, fmt.Sprintf("%s/stream?id=%s", baseMediaPath, mediaId)), nil)
 	if err != nil {
 		return
 	}
@@ -124,8 +123,8 @@ func (c *mediaHostClient) GetSettings(ctx context.Context) (result types.MediaHo
 	return
 }
 
-func (c *mediaHostClient) GetMediaArt(ctx context.Context, mediaId uuid.UUID) ([]byte, *http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, buildUriFromHost(c.host, fmt.Sprintf("%s/%s/art", baseMediaPath, mediaId.String())), nil)
+func (c *mediaHostClient) GetMediaArt(ctx context.Context, mediaId string) ([]byte, *http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, buildUriFromHost(c.host, fmt.Sprintf("%s/%s/art", baseMediaPath, mediaId)), nil)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
* **Added** handler for transfer ready messages, if the target is the current media host it will download the content to disk completing the transfer from node to node
* **Refactored** the fs event handler to move the debounce down, currently it was debouncing at the event level, therefore we could lose events of different types
* **Added** the directory of a item to the hash for mp3's since it is possible to have the same file in 2 different directories which would result in the same id
* **Fixed** logic in the delete handler in the fs watcher to not try to remove a directory from being watched if the file removed was not a directory