### PR TITLE
Fixes for transferring issues

### DIFF
--- a/internal/media/factories.go
+++ b/internal/media/factories.go
@@ -75,6 +75,7 @@ func mp3Factory(path string, ext string) (item types.MediaItem, err error) {
 				break
 			}
 
+			err = errD
 			return
 		}
 

--- a/internal/utils/arrays.go
+++ b/internal/utils/arrays.go
@@ -11,3 +11,13 @@ func Filter[T any](src []T, predicate func(arg T) bool) []T {
 
 	return result
 }
+
+func Contains[T comparable](src []T, value T) bool {
+	for _, v := range src {
+		if v == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/types/media.go
+++ b/pkg/types/media.go
@@ -9,6 +9,8 @@ type MediaItem struct {
 	Id        string      `json:"id"`
 	Metadata  interface{} `json:"metadata"`
 	// Top level directory this item belongs to
+	RootDir string `json:"-"`
+	// Direct parent of the item
 	ParentDir string `json:"-"`
 }
 


### PR DESCRIPTION
* **Added** a check in the fs watcher that will ignore events from specific files. Scenario observed was opening a watched folder in finder and .DS_Store was being changed on mac and resyncing the whole directory.
* **Fixed** an issue in the mp3 factory that was ignoring an error causing an item with no metadata being added to the cache and causing panics
* **Added** the root dir to the item as a temporary fix to remove items from the cache