### PR TITLE
Fs event batching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/egfanboy/mediapire-media-host
 go 1.18
 
 require (
-	github.com/bep/debounce v1.2.1
 	github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086
 	github.com/egfanboy/mediapire-common v0.0.0-20250221235900-73e3c8ad112f
 	github.com/fsnotify/fsnotify v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
-github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=

--- a/internal/utils/async-batch-processor.go
+++ b/internal/utils/async-batch-processor.go
@@ -3,8 +3,6 @@ package utils
 import (
 	"sync"
 	"time"
-
-	"github.com/rs/zerolog/log"
 )
 
 type AsyncBatchProcessor[T any] interface {
@@ -79,7 +77,7 @@ func (dr *asyncBatchProcessor[T]) triggerRead() {
 // processBatch reads all available items and processes them
 func (dr *asyncBatchProcessor[T]) processBatch() {
 	var batch []T
-	log.Debug().Msg("Processing Batch")
+
 	for {
 		select {
 		case v := <-dr.values:
@@ -87,8 +85,6 @@ func (dr *asyncBatchProcessor[T]) processBatch() {
 		default:
 			if len(batch) > 0 {
 				dr.processFn(batch) // Process batch
-			} else {
-				log.Debug().Msg("Nothing to processing")
 			}
 
 			return

--- a/pkg/types/media.go
+++ b/pkg/types/media.go
@@ -6,8 +6,6 @@ type MediaItem struct {
 	Path      string      `json:"-"`
 	Id        string      `json:"id"`
 	Metadata  interface{} `json:"metadata"`
-	// Top level directory this item belongs to
-	RootDir string `json:"-"`
 	// Direct parent of the item
 	ParentDir string `json:"-"`
 }


### PR DESCRIPTION
* **Implemented** event batch processing for other events not related to delete
* **Refactored** the media scanning to return a flat map where each key is the directories in the top level directories. This supports to be able to scan a single directory to handle changes
* **Removed** the `rootDir` value from media items since it no longer needed
* **Removed** the debounced package since it is no longer needed



