### PR TITLE
Messaging for update media

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086
-	github.com/egfanboy/mediapire-common v0.0.0-20250221235900-73e3c8ad112f
+	github.com/egfanboy/mediapire-common v0.0.0-20250304013840-abfbad75efae
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/google/uuid v1.4.0
 	github.com/gorilla/mux v1.8.0
@@ -35,4 +35,5 @@ require (
 
 //  uncomment for local development
 // replace github.com/egfanboy/mediapire-common => ../mediapire-common
+
 // replace github.com/egfanboy/mediapire-manager => ../mediapire-manager

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086 h1:ORubSQoKnncsBnR4zD9CuYFJCPOCuSNEpWEZrDdBXkc=
 github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086/go.mod h1:Z3Lomva4pyMWYezjMAU5QWRh0p1VvO4199OHlFnyKkM=
-github.com/egfanboy/mediapire-common v0.0.0-20250221235900-73e3c8ad112f h1:vQKhdqQA/GU2baJENfAZBlHm0YgglVMUR2HuEyQnx0o=
-github.com/egfanboy/mediapire-common v0.0.0-20250221235900-73e3c8ad112f/go.mod h1:PfxxoHTUvFmiaEvmipwuReMmo8jQqe9mhHtWODuL7OI=
+github.com/egfanboy/mediapire-common v0.0.0-20250304013840-abfbad75efae h1:ZkoRjZqOHGuMqVMEoNt5aLJ4+st2299WPGdhUYD9IrQ=
+github.com/egfanboy/mediapire-common v0.0.0-20250304013840-abfbad75efae/go.mod h1:PfxxoHTUvFmiaEvmipwuReMmo8jQqe9mhHtWODuL7OI=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=

--- a/internal/media/media-api.go
+++ b/internal/media/media-api.go
@@ -18,4 +18,6 @@ type MediaApi interface {
 	GetMediaArt(ctx context.Context, id string) ([]byte, error)
 	HandleFileSystemDeletions(ctx context.Context, files []string) error
 	UpdateItem(ctx context.Context, id string, newContent []byte) (types.MediaItem, error)
+	GetMediaItemById(ctx context.Context, id string) (types.MediaItem, error)
+	GetMediaItemByIdWithContent(ctx context.Context, id string) (types.MediaItemWithContent, error)
 }

--- a/internal/media/media-service.go
+++ b/internal/media/media-service.go
@@ -227,7 +227,7 @@ func (s *mediaService) StreamMedia(ctx context.Context, id string) ([]byte, erro
 }
 
 func (s *mediaService) getFilePathFromId(ctx context.Context, id string) (string, error) {
-	item, err := s.getMediaItemFromId(ctx, id)
+	item, err := s.GetMediaItemById(ctx, id)
 	if err != nil {
 		return "", err
 	}
@@ -235,7 +235,7 @@ func (s *mediaService) getFilePathFromId(ctx context.Context, id string) (string
 	return item.Path, nil
 }
 
-func (s *mediaService) getMediaItemFromId(ctx context.Context, id string) (types.MediaItem, error) {
+func (s *mediaService) GetMediaItemById(ctx context.Context, id string) (types.MediaItem, error) {
 	if item, ok := mediaLookup.GetKey(id); ok {
 		return item, nil
 	}
@@ -265,7 +265,7 @@ func (s *mediaService) DownloadMedia(ctx context.Context, ids []string) ([]byte,
 	items := make([]types.MediaItem, len(ids))
 
 	for i, itemId := range ids {
-		item, err := s.getMediaItemFromId(ctx, itemId)
+		item, err := s.GetMediaItemById(ctx, itemId)
 		if err != nil {
 			log.Err(err).Msgf("Failed to get item with id %q", itemId)
 			return nil, err
@@ -322,7 +322,7 @@ func (s *mediaService) DeleteMedia(ctx context.Context, ids []string) error {
 	failedToDelete := make([]string, 0)
 
 	for _, itemId := range ids {
-		item, err := s.getMediaItemFromId(ctx, itemId)
+		item, err := s.GetMediaItemById(ctx, itemId)
 		if err != nil {
 			failedToDelete = append(failedToDelete, fmt.Sprintf("Failed to get item with id %q", itemId))
 
@@ -384,7 +384,7 @@ func (s *mediaService) CleanupDownloadContent(ctx context.Context, transferId st
 }
 
 func (s *mediaService) GetMediaArt(ctx context.Context, id string) ([]byte, error) {
-	item, err := s.getMediaItemFromId(ctx, id)
+	item, err := s.GetMediaItemById(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -481,7 +481,7 @@ func (s *mediaService) HandleFileSystemDeletions(ctx context.Context, files []st
 }
 
 func (s *mediaService) UpdateItem(ctx context.Context, id string, newContent []byte) (types.MediaItem, error) {
-	item, err := s.getMediaItemFromId(ctx, id)
+	item, err := s.GetMediaItemById(ctx, id)
 	if err != nil {
 		return types.MediaItem{}, err
 	}
@@ -529,6 +529,26 @@ func (s *mediaService) UpdateItem(ctx context.Context, id string, newContent []b
 	}
 
 	return newItem, nil
+}
+
+func (s *mediaService) GetMediaItemByIdWithContent(ctx context.Context, id string) (result types.MediaItemWithContent, err error) {
+	log.Info().Msg("Start: GetMediaByIdWithContent")
+	mediaItem, err := s.GetMediaItemById(ctx, id)
+	if err != nil {
+		return
+	}
+
+	content, err := s.StreamMedia(ctx, id)
+	if err != nil {
+		return
+	}
+
+	result.MediaItem = mediaItem
+	result.Content = content
+
+	log.Info().Msg("End: GetMediaByIdWithContent")
+
+	return
 }
 
 func NewMediaService() MediaApi {

--- a/pkg/types/media.go
+++ b/pkg/types/media.go
@@ -10,4 +10,9 @@ type MediaItem struct {
 	ParentDir string `json:"-"`
 }
 
+type MediaItemWithContent struct {
+	MediaItem
+	Content []byte `json:"content"`
+}
+
 type DownloadRequest []string


### PR DESCRIPTION
* **Added** API to get a media item by id with the option to return its byte content
* **Added** the get media by id with and without content APIs to the client
* **Added** message handling that will take the updated content of items and update them on disk

Related: https://github.com/egfanboy/mediapire-common/pull/9