### PR TITLE
Added mechanism to persist ids

### DIFF
--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func getBasePath() (string, error) {
+func GetBasePath() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
@@ -19,7 +19,7 @@ func getBasePath() (string, error) {
 }
 
 func getDownloadPath() (string, error) {
-	basePath, err := getBasePath()
+	basePath, err := GetBasePath()
 	if err != nil {
 		return "", err
 	}
@@ -28,7 +28,7 @@ func getDownloadPath() (string, error) {
 }
 
 func getArtPath() (string, error) {
-	basePath, err := getBasePath()
+	basePath, err := GetBasePath()
 	if err != nil {
 		return "", err
 	}

--- a/internal/utils/concurrent-map.go
+++ b/internal/utils/concurrent-map.go
@@ -59,3 +59,11 @@ func NewConcurrentMap[K comparable, T any]() *ConcurrentMap[K, T] {
 	}
 	return m
 }
+
+func NewConcurrentMapFromData[K comparable, T any](data map[K]T) *ConcurrentMap[K, T] {
+	m := &ConcurrentMap[K, T]{
+		mu:   sync.Mutex{},
+		data: data,
+	}
+	return m
+}


### PR DESCRIPTION
Currently an id was calculated for an item based on it's metadata to have it be consistent between runs. However, if that metadata changes due to the edit functionality the id would need to change which would need to be propegated to the cache on the node itself, to the manager and finally to the UI. The main issue is if the id changes the reference to the old id just becomes stale on the UI and points the nothing.

Now, on startup the id will be a random UUID and after all files are scanned a file will be saved mapping the file path to a uuid. That way on subsequent startups the file will be read and the id will be reused from there. This means that if the metadata of a file changes the id remains constant. This way, even if technically the cache and the manager needs to be updated the UI won't break since the id remains constant and refetching the item will hold the updated metadata.